### PR TITLE
fix(totp): missing initial time value

### DIFF
--- a/totp/totp.go
+++ b/totp/totp.go
@@ -99,6 +99,9 @@ type ValidateOpts struct {
 
 	// Encoder to use for output code.
 	Encoder otp.Encoder
+
+	// InitialTime is the Unix time from which to start counting time steps (T0 per RFC 6238). Defaults to 0.
+	InitialTime uint64
 }
 
 // GenerateCodeCustom takes a timepoint and produces a passcode using a
@@ -109,7 +112,7 @@ func GenerateCodeCustom(secret string, t time.Time, opts ValidateOpts) (passcode
 		opts.Period = 30
 	}
 
-	counter := uint64(t.Unix()) / uint64(opts.Period)
+	counter := (uint64(t.Unix()) - opts.InitialTime) / uint64(opts.Period)
 	passcode, err = hotp.GenerateCodeCustom(secret, counter, hotp.ValidateOpts{
 		Digits:    opts.Digits,
 		Algorithm: opts.Algorithm,
@@ -136,7 +139,7 @@ func ValidateCustomStep(passcode string, secret string, t time.Time, opts Valida
 		opts.Period = 30
 	}
 
-	steps := []uint64{uint64(t.Unix()) / uint64(opts.Period)}
+	steps := []uint64{(uint64(t.Unix()) - opts.InitialTime) / uint64(opts.Period)}
 
 	for i := uint64(1); i <= uint64(opts.Skew); i++ {
 		steps = append(steps, steps[0]+i)

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -112,7 +112,7 @@ func GenerateCodeCustom(secret string, t time.Time, opts ValidateOpts) (passcode
 		opts.Period = 30
 	}
 
-	counter := (uint64(t.Unix()) - opts.InitialTime) / uint64(opts.Period)
+	counter := getT(uint64(t.Unix()), opts.InitialTime) / uint64(opts.Period)
 	passcode, err = hotp.GenerateCodeCustom(secret, counter, hotp.ValidateOpts{
 		Digits:    opts.Digits,
 		Algorithm: opts.Algorithm,
@@ -139,7 +139,7 @@ func ValidateCustomStep(passcode string, secret string, t time.Time, opts Valida
 		opts.Period = 30
 	}
 
-	steps := []uint64{(uint64(t.Unix()) - opts.InitialTime) / uint64(opts.Period)}
+	steps := []uint64{getT(uint64(t.Unix()), opts.InitialTime) / uint64(opts.Period)}
 
 	for i := uint64(1); i <= uint64(opts.Skew); i++ {
 		steps = append(steps, steps[0]+i)
@@ -242,4 +242,12 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 	}
 
 	return otp.NewKeyFromURL(u.String())
+}
+
+func getT(epoch, t0 uint64) uint64 {
+	if epoch < t0 {
+		return 0
+	}
+
+	return epoch - t0
 }

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -112,7 +112,7 @@ func GenerateCodeCustom(secret string, t time.Time, opts ValidateOpts) (passcode
 		opts.Period = 30
 	}
 
-	counter := getT(uint64(t.Unix()), opts.InitialTime) / uint64(opts.Period)
+	counter := getCounter(t, opts.InitialTime, opts.Period)
 	passcode, err = hotp.GenerateCodeCustom(secret, counter, hotp.ValidateOpts{
 		Digits:    opts.Digits,
 		Algorithm: opts.Algorithm,
@@ -139,7 +139,7 @@ func ValidateCustomStep(passcode string, secret string, t time.Time, opts Valida
 		opts.Period = 30
 	}
 
-	steps := []uint64{getT(uint64(t.Unix()), opts.InitialTime) / uint64(opts.Period)}
+	steps := []uint64{getCounter(t, opts.InitialTime, opts.Period)}
 
 	for i := uint64(1); i <= uint64(opts.Skew); i++ {
 		steps = append(steps, steps[0]+i)
@@ -244,7 +244,19 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 	return otp.NewKeyFromURL(u.String())
 }
 
-func getT(epoch, t0 uint64) uint64 {
+func getCounter(now time.Time, t0 uint64, X uint) uint64 {
+	t := getT(now, t0)
+
+	return t / uint64(X)
+}
+
+func getT(now time.Time, t0 uint64) uint64 {
+	if now.Unix() <= 0 {
+		return 0
+	}
+
+	epoch := uint64(now.Unix())
+
 	if epoch < t0 {
 		return 0
 	}


### PR DESCRIPTION
This fixes an issue where the missing time value from RFC6238 cannot be set.