### PR TITLE
fix(hotp): confusing parenthesis

### DIFF
--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -111,8 +111,8 @@ func GenerateCodeCustom(secret string, counter uint64, opts ValidateOpts) (passc
 	// http://tools.ietf.org/html/rfc4226#section-5.4
 	offset := sum[len(sum)-1] & 0xf
 	value := int64(((int(sum[offset]) & 0x7f) << 24) |
-		((int(sum[offset+1] & 0xff)) << 16) |
-		((int(sum[offset+2] & 0xff)) << 8) |
+		((int(sum[offset+1]) & 0xff) << 16) |
+		((int(sum[offset+2]) & 0xff) << 8) |
 		(int(sum[offset+3]) & 0xff))
 
 	l := opts.Digits.Length()


### PR DESCRIPTION
This fixes a minor issue where the masking parenthesis are slightly confusing.